### PR TITLE
Rebuild gdal-lib 3.4.1 against libtiledb with fixed pinning.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - patches/disable_doc.patch     # [win]
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports:
     - postgresql
     - icu                  [osx or win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -119,10 +119,13 @@ test:
     - gdalinfo http://thredds.nersc.no/thredds/dodsC/greenpath/Model/topaz  [unix]
 
 about:
-  home: http://www.gdal.org
+  home: https://www.gdal.org
   license: MIT
+  license_family: MIT
   license_file: LICENSE.TXT
   summary: |
     GDAL is a translator library for raster and vector geospatial data
     formats that is released under an X/MIT style Open Source license by
     the Open Source Geospatial Foundation.
+  dev_url: https://gdal.org/api/index.html
+  doc_url: https://gdal.org/tutorials/index.html

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,9 @@ source:
 
 build:
   number: 1
+  run_exports:
+    # Soname changes between minor versions.
+    - {{ pin_subpackage('libgdal', max_pin='x.x') }}
   ignore_run_exports:
     - postgresql
     - icu                  [osx or win]


### PR DESCRIPTION
tiledb didn't have a run_exports definition. gdal was linked against tiledb 2.2 but is being installed with 2.3, which results in a broken installation. Rebuild to remedy this and fix the pinning.

See also:

* https://github.com/AnacondaRecipes/tiledb-feedstock/pull/4
* https://github.com/AnacondaRecipes/tiledb-feedstock/pull/3